### PR TITLE
Ignore ./rails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vagrant
+rails


### PR DESCRIPTION
This allows users to have a clone in their rails-dev-box checkout that will automatically appear in their /vagrant folder. That way they can edit files "locally" and test the changes on the vagrant box.
