### PR TITLE
Add vagrant superuser to postgresql

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -70,6 +70,12 @@ class install_postgres {
     require => Class['postgresql::server'] 
   }
 
+  pg_user { 'vagrant':
+    ensure    => present,
+    superuser => true,
+    require   => Class['postgresql::server']
+  }
+
   package { 'libpq-dev':
     ensure => installed
   }


### PR DESCRIPTION
I got thi error when trying to run the ActiveRecord tests with the postgresql adapter in the vagrant box:

vagrant@rails-dev-box:/vagrant/rails/activerecord$ bundle exec rake test_postgresql
[..]
Using postgresql
/vagrant/rails/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:1466:in `initialize': FATAL: role "vagrant" does not exist (PG::Error)
[..]

The Contributing to Ruby on Rails guide recommends creating a PostgreSQL superuser with your shell user, and doing that fixes the issue. 
