### PR TITLE
Setting a default password for postgres database

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -66,11 +66,13 @@ class install_postgres {
   }
 
   pg_user { 'rails':
+    password=> 'rails',
     ensure  => present,
     require => Class['postgresql::server'] 
   }
 
   pg_user { 'vagrant':
+    password  => 'vagrant',
     ensure    => present,
     superuser => true,
     require   => Class['postgresql::server']


### PR DESCRIPTION
I had problem connecting to the postgres database when leaving out the password-field from the database yaml comfiguration file in my rails app.

I got this error when running `rake db:create`

`fe_sendauth: no password supplied`

Making the change i did in this pull-request fixed the issue for me once i updated the database configuration for the rails app.

How are you supposed to use the postgres database with the default rails-dev-box?

My apologies if i should have created an issue instead of an pull-request.
