### PR TITLE
Use fuzzy matching to set default ruby

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -130,7 +130,7 @@ exec { 'install_ruby':
   # The rvm executable is more suitable for automated installs.
   #
   # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 1.9.3 --latest-binary && rvm alias create default 1.9.3'",
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 1.9.3 --latest-binary && rvm --fuzzy alias create default 1.9.3'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
References https://github.com/rails/rails-dev-box/issues/16
### Summary

Installing ruby with `--latest-binary` does not guarantee the latest patchlevel, and rvm is extremely specific about what it allows when you don't specify a patchlevel:

```
vagrant@rails-dev-box:~$ rvm list

rvm rubies

   ruby-1.9.3-p374 [ i686 ]
```

```
vagrant@rails-dev-box:~$ rvm use 1.9.3
ruby-1.9.3-p392 is not installed.
To install do: 'rvm install ruby-1.9.3-p392'
```
### Proposed Solution

When setting the default ruby, use rvm `--fuzzy` flag to use the latest available version.
