### PR TITLE
Add postgres-contrib dependency so that hstore tests can run

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -85,6 +85,11 @@ class install_postgres {
   package { 'libpq-dev':
     ensure => installed
   }
+
+  package { 'postgresql-contrib':
+    ensure  => installed,
+    require => Class['postgresql::server'],
+  }
 }
 class { 'install_postgres': }
 


### PR DESCRIPTION
Without the `postgres-contrib` package, Postgres complains when Rails tries to create the test databases (since the hstore extension isn't available):

```
vagrant@rails-dev-box:~/rails/activerecord$ rake postgresql:drop_databases
vagrant@rails-dev-box:~/rails/activerecord$ rake postgresql:build_databases
ERROR:  could not open extension control file "/usr/share/postgresql/9.1/extension/hstore.control": No such file or directory
ERROR:  could not open extension control file "/usr/share/postgresql/9.1/extension/hstore.control": No such file or directory
```

I'm pretty sure this means the hstore tests are skipped*. This patch adds a Puppet dependency so that these tests can run.

*But I could totally be mistaken.
