### PR TITLE
rvm should not be considering installed until the bin is in place.

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -125,7 +125,7 @@ package { 'nodejs':
 
 exec { 'install_rvm':
   command => "${as_vagrant} 'curl -L https://get.rvm.io | bash -s stable'",
-  creates => "${home}/.rvm",
+  creates => "${home}/.rvm/bin/rvm",
   require => Package['curl']
 }
 


### PR DESCRIPTION
provision failed for me and then would not retry because .rvm existed, yet the install was not complete.  checking for a more completely rvm install should catch this type of thing
