### PR TITLE
update Vagrant docs link href to 1.1 from 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,4 @@ Finally, to completely wipe the virtual machine from the disk **destroying all i
 
     host $ vagrant destroy # DANGER: all is gone
 
-Please check the [Vagrant documentation](http://vagrantup.com/v1/docs/index.html) for more information on Vagrant.
+Please check the [Vagrant documentation](http://docs.vagrantup.com/v2/) for more information on Vagrant.


### PR DESCRIPTION
The README lists Vagrant 1.1+ as a requirement, but the link to the Vagrant docs were pointing to the 1.0 Vagrant docs.

This updates the link to point to Vagrant 1.1 docs
