### PR TITLE
Move default HBA rules

### DIFF
--- a/puppet/modules/postgresql/templates/pg_hba.conf.erb
+++ b/puppet/modules/postgresql/templates/pg_hba.conf.erb
@@ -81,10 +81,15 @@
 # Noninteractive access to all databases is required during automatic
 # maintenance (custom daily cronjobs, replication, and similar tasks).
 #
+# TYPE  DATABASE        USER            ADDRESS                 METHOD
+
 # Database administrative login by Unix domain socket
 local   all             postgres                                peer
 
-# TYPE  DATABASE        USER            ADDRESS                 METHOD
+# site-specific access control list
+<% acl.each do |entry| -%>
+<%= entry %>
+<% end -%>
 
 # "local" is for Unix domain socket connections only
 local   all             all                                     peer
@@ -93,10 +98,6 @@ host    all             all             127.0.0.1/32            md5
 # IPv6 local connections:
 host    all             all             ::1/128                 md5
 
-# site-specific access control list
-<% acl.each do |entry| -%>
-<%= entry %>
-<% end -%>
 
 # Allow replication connections from localhost, by a user with the
 # replication privilege.


### PR DESCRIPTION
- Postgres HBA honors the first matching rule; setting defaults first
  prevents puppet from overriding these defaults
