### PR TITLE
use nfs for better i/o performance on the synced directory

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,10 @@ Vagrant.configure('2') do |config|
   config.vm.box_url  = 'http://files.vagrantup.com/precise32.box'
   config.vm.hostname = 'rails-dev-box'
 
+  config.vm.network "private_network", ip: "192.168.50.4"
   config.vm.network :forwarded_port, guest: 3000, host: 3000
+
+  config.vm.synced_folder ".", "/vagrant", nfs: true
 
   config.vm.provision :puppet do |puppet|
     puppet.manifests_path = 'puppet/manifests'


### PR DESCRIPTION
Use nfs for the synced `/vagrant` directory to speed up i/o.

This improved performance ~10% when running all activerecord tests on my 2011 Macbook Air. There are a couple of downsides to consider, not sure if these are dealbreakers:
- Will not work in Windows
- Requires to you enter your password for root privileges when starting the VM
