### PR TITLE
get editors to recognize Vagrantfile as ruby

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,3 +1,6 @@
+# -*- mode: ruby -*-
+# # vi: set ft=ruby :
+
 Vagrant.configure('2') do |config|
   config.vm.box      = 'precise32'
   config.vm.box_url  = 'http://files.vagrantup.com/precise32.box'


### PR DESCRIPTION
This just adds a couple of comments to `Vagrantfile` so that editors (e.g. vim) will recognize it as a ruby file and apply syntax highlighting, etc. In the current version of vagrant these are already included in the `Vagrantfile` generated by `vagrant init`.
