### PR TITLE
for the ruby install, use a ruby patch level known to have a binary

### DIFF
--- a/puppet/manifests/default.pp
+++ b/puppet/manifests/default.pp
@@ -134,8 +134,8 @@ exec { 'install_ruby':
   # interactive environment, in particular to display messages or ask questions.
   # The rvm executable is more suitable for automated installs.
   #
-  # Thanks to @mpapis for this tip.
-  command => "${as_vagrant} '${home}/.rvm/bin/rvm install 2.0 --fuzzy --binary --autolibs=enabled && rvm --fuzzy alias create default 2.0'",
+  # use a ruby patch level known to have a binary
+  command => "${as_vagrant} '${home}/.rvm/bin/rvm install ruby-2.0.0-p353 --binary --autolibs=enabled && rvm alias create default 2.0'",
   creates => "${home}/.rvm/bin/ruby",
   require => Exec['install_rvm']
 }


### PR DESCRIPTION
Once the ruby 2.0.0-p451 binary becomes available, this work-around will require an update
