### PR TITLE
Update Ruby version noted in README to 2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Port 3000 in the host computer is forwarded to port 3000 in the virtual machine.
 
 * RVM
 
-* Ruby 2.0.0 (binary RVM install)
+* Ruby 2.1.1 (binary RVM install)
 
 * Bundler
 


### PR DESCRIPTION
Ruby version changed to 2.1.1 in this commit, whereas README lists Ruby version as 2.0.0 https://github.com/rails/rails-dev-box/commit/0f2143cd3cc2ab8ec596956ab46e1b34de0724f6
