### PR TITLE
Added URL for vagrant box

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
   config.vm.box      = 'ubuntu/trusty32'
+  config.vm.box_url  = 'http://cloud-images.ubuntu.com/vagrant/trusty/trusty-server-cloudimg-i386-juju-vagrant-disk1.box'
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000


### PR DESCRIPTION
This allows new versions of vagrant to auto-download
the box image without being pre-configured
