### PR TITLE
Update README for port-forwarding clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,11 @@ After the installation has finished, you can access the virtual machine with
     ...
     vagrant@rails-dev-box:~$
 
-Port 3000 in the host computer is forwarded to port 3000 in the virtual machine. Thus, applications running in the virtual machine can be accessed via localhost:3000 in the host computer.
+Port 3000 in the host computer is forwarded to port 3000 in the virtual machine. Thus, applications running in the virtual machine can be accessed via localhost:3000 in the host computer. If you are running into issues accessing your application on your host, be sure that WEBrick or any other web server you use is bound to the IP `0.0.0.0`, instead of `127.0.0.1` so it can access all interfaces.
+
+In WEBrick you would do
+
+    bin/rails server -b 0.0.0.0
 
 ## What's In The Box
 


### PR DESCRIPTION
Often times it's necessary to run WEBrick or any other web server in ip address `0.0.0.0`, instead of `127.0.0.1` which is loopback. Binding to `0.0.0.0` ensures that the server is accessible in all interfaces and works as expected. Many new collaborators can get stuck in this simple hurdle, and there are little to no docs on it available.