### PR TITLE
Update to use ruby 2.2.0

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -12,9 +12,9 @@ apt-get -y update >/dev/null 2>&1
 
 install 'development tools' build-essential
 
-install Ruby ruby2.1 ruby2.1-dev
-update-alternatives --set ruby /usr/bin/ruby2.1 >/dev/null 2>&1
-update-alternatives --set gem /usr/bin/gem2.1 >/dev/null 2>&1
+install Ruby ruby2.2 ruby2.2-dev
+update-alternatives --set ruby /usr/bin/ruby2.2 >/dev/null 2>&1
+update-alternatives --set gem /usr/bin/gem2.2 >/dev/null 2>&1
 
 echo installing Bundler
 gem install bundler -N >/dev/null 2>&1


### PR DESCRIPTION
Since rails/rails@3b098b8289ffaa8486f526dc53204123ed581f3, rails requires ruby 2.2.0.