### PR TITLE
Switch to the 64 bit trusty image

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'ubuntu/trusty32'
+  config.vm.box      = 'ubuntu/trusty64'
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # The output of all these installation steps is noisy. With this utility
 # the progress report is nice and concise.
 function install {


### PR DESCRIPTION
You can't buy 32-bit hardware for x86 from mainstream hardware vendors anymore so it doesn't make much sense to use it here. There are some advantages around memory usage, but they're so small at this point that it's far more important to get closer to platform affinity for what people are deploying their applications to.