### PR TITLE
Add swapfile to avoid `Errno::ENOMEM: Cannot allocate memory - fork(2)`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,13 @@ function install {
     apt-get -y install "$@" >/dev/null 2>&1
 }
 
+echo adding swap file
+fallocate -l 2G /swapfile
+chmod 600 /swapfile
+mkswap /swapfile
+swapon /swapfile
+echo '/swapfile none swap defaults 0 0' >> /etc/fstab
+
 echo updating package information
 apt-add-repository -y ppa:brightbox/ruby-ng >/dev/null 2>&1
 apt-get -y update >/dev/null 2>&1


### PR DESCRIPTION
This pull request addresses that ActiveRecord unit tests get `Killed` or get `Errno::ENOMEM: Cannot allocate memory - fork(2)` errors by adding 2GB swapfile. Thanks to http://jeqo.github.io/blog/devops/vagrant-quickstart/

1. Environment
VirtualBox 5.0.2
Vagrant 1.7.4

2. Steps to reproduce

- At host
> cd rails-dev-box
> vagrant up
> vagrant ssh

- At Guest
```ruby
$ git clone https://github.com/rails/rails.git
$ cd rails/activerecord
$ bundle
$ rake test
... snip ...
Using mysql
Run options: --seed 4073

# Running:

... snip ...

Finished in 134.991014s, 34.3282 runs/s, 94.8656 assertions/s.

  1) Error:
BasicsTest#test_marshal_between_processes:
Errno::ENOMEM: Cannot allocate memory - fork(2)
    /home/vagrant/rails/activerecord/test/cases/base_test.rb:1370:in `fork'
    /home/vagrant/rails/activerecord/test/cases/base_test.rb:1370:in `test_marshal_between_processes'


  2) Error:
ActiveRecord::ConnectionAdapters::ConnectionHandlerTest#test_connection_pool_per_pid:
Errno::ENOMEM: Cannot allocate memory - fork(2)
    /home/vagrant/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb:58:in `fork'
    /home/vagrant/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb:58:in `test_connection_pool_per_pid'


  3) Error:
ActiveRecord::ConnectionAdapters::ConnectionHandlerTest#test_retrieve_connection_pool_copies_schema_cache_from_ancestor_pool:
Errno::ENOMEM: Cannot allocate memory - fork(2)
    /home/vagrant/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb:80:in `fork'
    /home/vagrant/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb:80:in `test_retrieve_connection_pool_copies_schema_cache_from_ancestor_pool'


  4) Error:
MysqlStatementPoolTest#test_cache_is_per_pid:
Errno::ENOMEM: Cannot allocate memory - fork(2)
    /home/vagrant/rails/activerecord/test/cases/adapters/mysql/statement_pool_test.rb:10:in `fork'
    /home/vagrant/rails/activerecord/test/cases/adapters/mysql/statement_pool_test.rb:10:in `test_cache_is_per_pid'


  5) Error:
ActiveRecord::ConnectionAdapters::MysqlSchemaTest#test_table_exists_wrong_schema:
ActiveRecord::StatementInvalid: Mysql::Error: Table 'mysql_doubles' already exists: CREATE TABLE `mysql_doubles` (`id` int(11) AUTO_INCREMENT PRIMARY KEY) ENGINE=InnoDB
    /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:427:in `query'
    /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:427:in `block in execute'
    /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:514:in `block in log'
    /home/vagrant/rails/activesupport/lib/active_support/notifications/instrumenter.rb:20:in `instrument'
    /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:508:in `log'
    /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:427:in `execute'
    /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/schema_statements.rb:227:in `create_table'
    /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:590:in `create_table'
    /home/vagrant/rails/activerecord/test/cases/adapters/mysql/schema_test.rb:21:in `setup'

4634 runs, 12806 assertions, 0 failures, 5 errors, 5 skips

You have skipped tests. Run with --verbose for details.
... snip ...
Using mysql2
Run options: --seed 63125

# Running:

... snip ...
Finished in 96.708022s, 47.7623 runs/s, 132.2227 assertions/s.

  1) Error:
BasicsTest#test_marshal_between_processes:
Errno::ENOMEM: Cannot allocate memory - fork(2)
    /home/vagrant/rails/activerecord/test/cases/base_test.rb:1370:in `fork'
    /home/vagrant/rails/activerecord/test/cases/base_test.rb:1370:in `test_marshal_between_processes'


  2) Error:
ActiveRecord::ConnectionAdapters::ConnectionHandlerTest#test_connection_pool_per_pid:
Errno::ENOMEM: Cannot allocate memory - fork(2)
    /home/vagrant/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb:58:in `fork'
    /home/vagrant/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb:58:in `test_connection_pool_per_pid'


  3) Error:
ActiveRecord::ConnectionAdapters::ConnectionHandlerTest#test_retrieve_connection_pool_copies_schema_cache_from_ancestor_pool:
Errno::ENOMEM: Cannot allocate memory - fork(2)
    /home/vagrant/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb:80:in `fork'
    /home/vagrant/rails/activerecord/test/cases/connection_adapters/connection_handler_test.rb:80:in `test_retrieve_connection_pool_copies_schema_cache_from_ancestor_pool'

4619 runs, 12787 assertions, 0 failures, 3 errors, 5 skips

You have skipped tests. Run with --verbose for details.
... snip ...
Using sqlite3
Run options: --seed 64600

# Running:

... snip ...
..................................................................................................................E.......Killed
... snip ...
Using postgresql
Run options: --seed 48580

# Running:

... snip ...
...........................................................................................................................Killed
Errors running test_mysql, test_mysql2, test_sqlite3, test_postgresql
$
```

With this commit, it does not cause `Errno::ENOMEM: Cannot allocate memory - fork(2)` or `Killed` errors. It shows this error but I think it is not related with rails-dev-box.
```ruby
...
Finished in 130.505990s, 38.5500 runs/s, 105.6810 assertions/s.

  1) Error:
DateTimePrecisionTest#test_formatting_datetime_according_to_precision:
ActiveModel::UnknownAttributeError: unknown attribute 'created_at' for DateTimePrecisionTest::Foo.
    /home/vagrant/rails/activerecord/lib/active_record/attribute_assignment.rb:37:in `rescue in _assign_attribute'
    /home/vagrant/rails/activerecord/lib/active_record/attribute_assignment.rb:35:in `_assign_attribute'
    /home/vagrant/rails/activemodel/lib/active_model/attribute_assignment.rb:40:in `block in _assign_attributes'
    /home/vagrant/rails/activemodel/lib/active_model/attribute_assignment.rb:39:in `each'
    /home/vagrant/rails/activemodel/lib/active_model/attribute_assignment.rb:39:in `_assign_attributes'
    /home/vagrant/rails/activerecord/lib/active_record/attribute_assignment.rb:26:in `_assign_attributes'
    /home/vagrant/rails/activemodel/lib/active_model/attribute_assignment.rb:33:in `assign_attributes'
    /home/vagrant/rails/activerecord/lib/active_record/core.rb:305:in `initialize'
    /home/vagrant/rails/activerecord/lib/active_record/inheritance.rb:61:in `new'
    /home/vagrant/rails/activerecord/lib/active_record/inheritance.rb:61:in `new'
    /home/vagrant/rails/activerecord/lib/active_record/persistence.rb:50:in `create!'
    /home/vagrant/rails/activerecord/test/cases/date_time_precision_test.rb:65:in `test_formatting_datetime_according_to_precision'

5031 runs, 13792 assertions, 0 failures, 1 errors, 19 skips

You have skipped tests. Run with --verbose for details.
Errors running test_postgresql
$
```