### PR TITLE
Rails test suite fails on 1024MB

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,7 @@ Vagrant.configure('2') do |config|
   config.vm.provision :shell, path: 'bootstrap.sh', keep_color: true
 
   config.vm.provider 'virtualbox' do |v|
-    v.memory = 1024
+    v.memory = 4096
     v.cpus = 2
   end
 end


### PR DESCRIPTION
The rails test suite does not pass with the configured default of 1024mb
of memory on the VM this is also in line with issue #102. 4GB seem like
a more sensible default, as in todays day it can be expected that the
host system has 8GB or more.