### PR TITLE
Use Ruby 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Port 3000 in the host computer is forwarded to port 3000 in the virtual machine.
 
 * Git
 
-* Ruby 2.3
+* Ruby 2.4
 
 * Bundler
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -19,9 +19,9 @@ apt-get -y update >/dev/null 2>&1
 
 install 'development tools' build-essential
 
-install Ruby ruby2.3 ruby2.3-dev
-update-alternatives --set ruby /usr/bin/ruby2.3 >/dev/null 2>&1
-update-alternatives --set gem /usr/bin/gem2.3 >/dev/null 2>&1
+install Ruby ruby2.4 ruby2.4-dev
+update-alternatives --set ruby /usr/bin/ruby2.4 >/dev/null 2>&1
+update-alternatives --set gem /usr/bin/gem2.4 >/dev/null 2>&1
 
 echo installing Bundler
 gem install bundler -N >/dev/null 2>&1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -26,6 +26,9 @@ update-alternatives --set gem /usr/bin/gem2.4 >/dev/null 2>&1
 echo installing Bundler
 gem install bundler -N >/dev/null 2>&1
 
+echo updating rubygems
+gem update --system -N >/dev/null 2>&1
+
 install Git git
 install SQLite sqlite3 libsqlite3-dev
 install memcached memcached


### PR DESCRIPTION
This pull request adds  * [Ruby 2.4 Ubuntu packages](https://www.brightbox.com/blog/2017/01/13/ruby-2-4-ubuntu-packages/?utm_source=rubyweekly&utm_medium=email) to rails-dev-box.

Also addresses `can't modify frozen String` error when installing rainbow.

```ruby
$ cd rails
$ bundle install
... snip ...
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    can't modify frozen String

Gem files will remain installed in /tmp/bundler20170131-15832-xwb8u7rainbow-2.2.1/gems/rainbow-2.2.1 for inspection.
Results logged to /tmp/bundler20170131-15832-xwb8u7rainbow-2.2.1/extensions/x86_64-linux/2.4.0/rainbow-2.2.1/gem_make.out

An error occurred while installing rainbow (2.2.1), and Bundler cannot continue.
Make sure that `gem install rainbow -v '2.2.1'` succeeds before bundling.
``` 
This error can also reproduce with Ruby 2.3. At rails itself it has been addressed by updating the latest rubygems by [this commit](https://github.com/rails/rails/commit/ab7be563250e9b911243b773fedc7ff225ba3f33) .