### PR TITLE
Use PostgreSQL 9.6

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,8 @@ echo '/swapfile none swap defaults 0 0' >> /etc/fstab
 
 echo updating package information
 apt-add-repository -y ppa:brightbox/ruby-ng >/dev/null 2>&1
+add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" > /dev/null 2>&1
+wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - > /dev/null 2>&1
 apt-get -y update >/dev/null 2>&1
 
 install 'development tools' build-essential


### PR DESCRIPTION
This pull request upgrades PostgreSQL version to 9.6.

```sql
ubuntu@rails-dev-box:~$ psql -d postgres 
psql (9.6.1)
Type "help" for help.

postgres=# select version();
                                                 version                                                  
----------------------------------------------------------------------------------------------------------
 PostgreSQL 9.6.1 on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 5.3.1-14ubuntu2) 5.3.1 20160413, 64-bit
(1 row)

postgres=# 
```

Reference:
* [Apt - PostgreSQL wiki](https://wiki.postgresql.org/wiki/Apt)
* [I am using a non-LTS release of Ubuntu](https://wiki.postgresql.org/wiki/Apt/FAQ#I_am_using_a_non-LTS_release_of_Ubuntu)
