### PR TITLE
Revert "Update rubygems to the latest one"

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -29,9 +29,6 @@ gem update --system -N >/dev/null 2>&1
 echo installing Bundler
 gem install bundler -N >/dev/null 2>&1
 
-echo updating rubygems
-gem update --system -N >/dev/null 2>&1
-
 install Git git
 install SQLite sqlite3 libsqlite3-dev
 install memcached memcached


### PR DESCRIPTION
This reverts commit c17c63082795f5b6e99b3f20a05623ae4f50d976.

This pull request addresses duplicate `gem update --system -N >/dev/null 2>&1` entries.
gem update should be done before using gem command, then 2nd one is removed.