### PR TITLE
Add log files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .vagrant
+*.log
 rails


### PR DESCRIPTION
After spinning up the dev box, I ended up with a top-level `ubuntu-yakkety-16.10-cloudimg-console.log` file, dirtying my git stage.  All `.log` files should probably just be ignored.