### PR TITLE
Use Ubuntu 17.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ That's it.
 After the installation has finished, you can access the virtual machine with
 
     host $ vagrant ssh
-    Welcome to Ubuntu 16.10 (GNU/Linux 4.8.0-26-generic x86_64)
+    Welcome to Ubuntu 17.04 (GNU/Linux 4.10.0-21-generic x86_64)
     ...
     ubuntu@rails-dev-box:~$
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'ubuntu/yakkety64' # 16.10
+  config.vm.box      = 'ubuntu/zesty64' # 17.04
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000


### PR DESCRIPTION
This pull request updates Ubuntu version from 16.10 to 17.04. 

Ubuntu 17.04 installs the latest version of PostgreSQL 9.6 by default.  #130 requested to upgrade PostgreSQL to 9.6 on Ubuntu 16.10, which was not the default one.
