### PR TITLE
Use Ubuntu 17.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ That's it.
 After the installation has finished, you can access the virtual machine with
 
     host $ vagrant ssh
-    Welcome to Ubuntu 17.04 (GNU/Linux 4.10.0-21-generic x86_64)
+    Welcome to Ubuntu 17.10 (GNU/Linux 4.13.0-16-generic x86_64)
     ...
-    ubuntu@rails-dev-box:~$
+    vagrant@rails-dev-box:~$
 
 Port 3000 in the host computer is forwarded to port 3000 in the virtual machine. Thus, applications running in the virtual machine can be accessed via localhost:3000 in the host computer. Be sure the web server is bound to the IP 0.0.0.0, instead of 127.0.0.1, so it can access all interfaces:
 
@@ -73,13 +73,13 @@ Just clone your Rails fork into the rails-dev-box directory on the host computer
 
 Vagrant mounts that directory as _/vagrant_ within the virtual machine:
 
-    ubuntu@rails-dev-box:~$ ls /vagrant
+    vagrant@rails-dev-box:~$ ls /vagrant
     bootstrap.sh MIT-LICENSE rails README.md Vagrantfile
 
 Install gem dependencies in there:
 
-    ubuntu@rails-dev-box:~$ cd /vagrant/rails
-    ubuntu@rails-dev-box:/vagrant/rails$ bundle
+    vagrant@rails-dev-box:~$ cd /vagrant/rails
+    vagrant@rails-dev-box:/vagrant/rails$ bundle
 
 We are ready to go to edit in the host, and test in the virtual machine.
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'ubuntu/zesty64' # 17.04
+  config.vm.box      = 'ubuntu/artful64' # 17.10
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,11 @@ function install {
     apt-get -y install "$@" >/dev/null 2>&1
 }
 
+# Workaround for https://bugs.launchpad.net/cloud-images/+bug/1726818
+# without this the root file system size will be about 2GB
+echo expanding root file system
+sudo resize2fs /dev/sda1
+
 echo adding swap file
 fallocate -l 2G /swapfile
 chmod 600 /swapfile
@@ -36,9 +41,9 @@ install Redis redis-server
 install RabbitMQ rabbitmq-server
 
 install PostgreSQL postgresql postgresql-contrib libpq-dev
-sudo -u postgres createuser --superuser ubuntu
-sudo -u postgres createdb -O ubuntu activerecord_unittest
-sudo -u postgres createdb -O ubuntu activerecord_unittest2
+sudo -u postgres createuser --superuser vagrant
+sudo -u postgres createdb -O vagrant activerecord_unittest
+sudo -u postgres createdb -O vagrant activerecord_unittest2
 
 debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
 debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'


### PR DESCRIPTION
- Unix username is back to `vagrant`
- Need to implement workaround for https://bugs.launchpad.net/cloud-images/+bug/1726818
  "vagrant artful64 box filesystem too small"