### PR TITLE
Fix syntax highlight for bootstrap.sh

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # The output of all these installation steps is noisy. With this utility
 # the progress report is nice and concise.
 function install {


### PR DESCRIPTION
This will make editors like vim detect bash syntax and not mess with
fancy stuff like <<<.