### PR TITLE
Use empty string for mysql root user password

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -54,6 +54,7 @@ debconf-set-selections <<< 'mysql-server mysql-server/root_password_again passwo
 install MySQL mysql-server libmysqlclient-dev
 # Set the password in an environment variable to avoid the warning issued if set with `-p`.
 MYSQL_PWD=root mysql -uroot <<SQL
+SET PASSWORD = '';
 CREATE USER 'rails'@'localhost';
 CREATE DATABASE activerecord_unittest  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
 CREATE DATABASE activerecord_unittest2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;


### PR DESCRIPTION
so that users can login to mysql without typing password.

Addresses #122 

```sql
vagrant@rails-dev-box:~$ mysql -uroot
Welcome to the MySQL monitor.  Commands end with ; or \g.
Your MySQL connection id is 6
Server version: 5.7.20-0ubuntu0.17.10.1 (Ubuntu)

Copyright (c) 2000, 2017, Oracle and/or its affiliates. All rights reserved.

Oracle is a registered trademark of Oracle Corporation and/or its
affiliates. Other names may be trademarks of their respective
owners.

Type 'help;' or '\h' for help. Type '\c' to clear the current input statement.

mysql>
```