### PR TITLE
Install "poppler-utils" to support Active Storage unit test

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -78,6 +78,7 @@ rm $kindlegen_tarball
 
 install 'MuPDF' mupdf mupdf-tools
 install 'FFmpeg' ffmpeg
+install 'Poppler' poppler-utils
 
 # Needed for docs generation.
 update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8


### PR DESCRIPTION
This pull request addresses the following error by installing `pdftoppm` to the guest OS which was added to rails/rails by https://github.com/rails/rails/commit/0b717c20458d12191f479fc693dd1ca1eb11c050

```ruby
$ git clone https://github.com/rails/rails.git
$ cd rails/activestorage
$ bundle
$ bundle exec ruby -Itest test/previewer/poppler_pdf_previewer_test.rb
Missing service configuration file in test/service/configurations.yml
== 20170806125915 CreateActiveStorageTables: migrating ========================
-- create_table(:active_storage_blobs)
   -> 0.0023s
-- create_table(:active_storage_attachments)
   -> 0.0031s
== 20170806125915 CreateActiveStorageTables: migrated (0.0056s) ===============

==  ActiveStorageCreateUsers: migrating =======================================
-- create_table(:users)
   -> 0.0009s
==  ActiveStorageCreateUsers: migrated (0.0013s) ==============================

Run options: --seed 61510

# Running:

E

Error:
ActiveStorage::Previewer::PopplerPDFPreviewerTest#test_previewing_a_PDF_document:
Errno::ENOENT: No such file or directory - pdftoppm
    test/previewer/poppler_pdf_previewer_test.rb:14:in `block in <class:PopplerPDFPreviewerTest>'


bin/rails test test/previewer/poppler_pdf_previewer_test.rb:13



Finished in 0.063341s, 15.7875 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```
