### PR TITLE
Use bundled Ruby 2.5

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,14 +15,10 @@ swapon /swapfile
 echo '/swapfile none swap defaults 0 0' >> /etc/fstab
 
 echo updating package information
-apt-add-repository -y ppa:brightbox/ruby-ng >/dev/null 2>&1
 apt-get -y update >/dev/null 2>&1
 
+install Ruby ruby-full
 install 'development tools' build-essential autoconf libtool
-
-install Ruby ruby2.5 ruby2.5-dev
-update-alternatives --set ruby /usr/bin/ruby2.5 >/dev/null 2>&1
-update-alternatives --set gem /usr/bin/gem2.5 >/dev/null 2>&1
 
 # echo installing current RubyGems
 gem update --system -N >/dev/null 2>&1


### PR DESCRIPTION
This pull request changes to use bundled Ruby 2.5

Ubuntu 18.04 LTS supports Ruby 2.5 without 3rd party tools.
https://packages.ubuntu.com/bionic/ruby

`ruby-full` is a Ubuntu package name to install Ruby via apt
https://launchpad.net/ubuntu/bionic/+package/ruby-full
https://www.ruby-lang.org/en/documentation/installation/#apt

```ruby
vagrant@rails-dev-box:~$ ruby -v
ruby 2.5.1p57 (2018-03-29 revision 63029) [x86_64-linux-gnu]
vagrant@rails-dev-box:~$ gem -v
2.7.7
vagrant@rails-dev-box:~$ bundle -v
Bundler version 1.16.2
vagrant@rails-dev-box:~$ which ruby
/usr/bin/ruby
vagrant@rails-dev-box:~$ which gem
/usr/bin/gem
```

I have confirmed Rails unit test runs with this change.