### PR TITLE
Use the same create database option as Rails Rakefile

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -34,8 +34,8 @@ install RabbitMQ rabbitmq-server
 
 install PostgreSQL postgresql postgresql-contrib libpq-dev
 sudo -u postgres createuser --superuser vagrant
-sudo -u postgres createdb -O vagrant activerecord_unittest
-sudo -u postgres createdb -O vagrant activerecord_unittest2
+sudo -u postgres createdb -O vagrant -E UTF8 -T template0 activerecord_unittest
+sudo -u postgres createdb -O vagrant -E UTF8 -T template0 activerecord_unittest2
 
 debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
 debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'
@@ -43,8 +43,8 @@ install MySQL mysql-server libmysqlclient-dev
 # Set the password in an environment variable to avoid the warning issued if set with `-p`.
 MYSQL_PWD=root mysql -uroot <<SQL
 CREATE USER 'rails'@'localhost';
-CREATE DATABASE activerecord_unittest  DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
-CREATE DATABASE activerecord_unittest2 DEFAULT CHARACTER SET utf8 DEFAULT COLLATE utf8_general_ci;
+CREATE DATABASE activerecord_unittest  DEFAULT CHARACTER SET utf8mb4;
+CREATE DATABASE activerecord_unittest2 DEFAULT CHARACTER SET utf8mb4;
 GRANT ALL PRIVILEGES ON activerecord_unittest.* to 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON activerecord_unittest2.* to 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to 'rails'@'localhost';


### PR DESCRIPTION
This pull request updates create database options for MySQL and PostgreSQL databases.

* DEFAULT CHARACTER SET utf8mb4 for MySQL

https://github.com/rails/rails/blob/5431e17733366da1fd10f2cd3039d66a56012683/activerecord/Rakefile#L97-L98

```ruby
%x( mysql --user=#{config["arunit"]["username"]} --password=#{config["arunit"]["password"]} -e "create DATABASE #{config["arunit"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
%x( mysql --user=#{config["arunit2"]["username"]} --password=#{config["arunit2"]["password"]} -e "create DATABASE #{config["arunit2"]["database"]} DEFAULT CHARACTER SET utf8mb4" )
```

* Do not specify `DEFAULT COLLATE` as Rails Raketask removed

https://github.com/rails/rails/commit/d54d0c95750e2693da495b75ac5fa0280253972d#diff-6c25b8e13c63a297ab5298948548caef

> There should be no "one size fits all" collation in MySQL 5.7.
> Let MySQL server choose the default collation for Active Record
> unit test databases.

* Use `-E UTF8 -T template0` option for PostgreSQL database

https://github.com/rails/rails/blob/5431e17733366da1fd10f2cd3039d66a56012683/activerecord/Rakefile#L116-L117

```ruby
%x( createdb -E UTF8 -T template0 #{config["arunit"]["database"]} )
%x( createdb -E UTF8 -T template0 #{config["arunit2"]["database"]} )
```