### PR TITLE
Install Yarn

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -15,6 +15,8 @@ swapon /swapfile
 echo '/swapfile none swap defaults 0 0' >> /etc/fstab
 
 echo updating package information
+curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - >/dev/null 2>&1
+echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list >/dev/null 2>&1
 apt-get -y update >/dev/null 2>&1
 
 install Ruby ruby-full
@@ -31,6 +33,7 @@ install SQLite sqlite3 libsqlite3-dev
 install memcached memcached
 install Redis redis-server
 install RabbitMQ rabbitmq-server
+install Yarn yarn
 
 install PostgreSQL postgresql postgresql-contrib libpq-dev
 sudo -u postgres createuser --superuser vagrant


### PR DESCRIPTION
This pull request installs `yarn` 1.12.1 to support Rails 6 Webpacker.

### Installation guide:
https://yarnpkg.com/en/docs/install#debian-stable

### Steps to reproduce:

```ruby
> vagrant up
> vagrant ssh
$ git clone https://github.com/rails/rails.git
$ cd railties
$ bundle install
$ bundle exec rake test
```

### Actual result without this pull request:
```
vagrant@rails-dev-box:~/rails/railties$ bundle exec rake test
rake aborted!
Errno::ENOENT: No such file or directory - yarn
/home/vagrant/rails/railties/test/isolation/abstract_unit.rb:478:in ``'
/home/vagrant/rails/railties/test/isolation/abstract_unit.rb:478:in `block (2 levels) in <top (required)>'
/home/vagrant/rails/railties/test/isolation/abstract_unit.rb:477:in `chdir'
/home/vagrant/rails/railties/test/isolation/abstract_unit.rb:477:in `block in <top (required)>'
/home/vagrant/rails/railties/test/isolation/abstract_unit.rb:470:in `initialize'
/home/vagrant/rails/railties/test/isolation/abstract_unit.rb:470:in `new'
/home/vagrant/rails/railties/test/isolation/abstract_unit.rb:470:in `<top (required)>'
/home/vagrant/rails/railties/Rakefile:32:in `require_relative'
/home/vagrant/rails/railties/Rakefile:32:in `block (2 levels) in <top (required)>'
Tasks: TOP => test => test:isolated
(See full trace by running task with --trace)
vagrant@rails-dev-box:~/rails/railties$ pwd
/home/vagrant/rails/railties
vagrant@rails-dev-box:~/rails/railties$
```

### Note:

`yarn` pkg available from the Ubuntu distribution is version 0.32, which does not satisfy the Webpacker requirement.

```
$ bundle exec rake test
00h00m00s 0/0: : ERROR: [Errno 2] No such file or directory: 'build'
Webpacker requires Yarn >= 1.0.0 and you are using 0.32
Please upgrade Yarn https://yarnpkg.com/lang/en/docs/install/
00h00m00s 0/0: : ERROR: [Errno 2] No such file or directory: 'add'
Usage: yarn [options]

yarn: error: no such option: --tilde
```

### Installed yarn version by this pull request:
```
$  yarn -v
1.12.1
```
