### PR TITLE
Use Ubuntu 19.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ That's it.
 After the installation has finished, you can access the virtual machine with
 
     host $ vagrant ssh
-    Welcome to Ubuntu 19.04 (GNU/Linux 5.0.0-13-generic x86_64)
+    Welcome to Ubuntu 19.10 (GNU/Linux 5.3.0-18-generic x86_64)
     ...
     vagrant@rails-dev-box:~$
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,4 +12,7 @@ Vagrant.configure('2') do |config|
     v.memory = ENV.fetch('RAILS_DEV_BOX_RAM', 2048).to_i
     v.cpus   = ENV.fetch('RAILS_DEV_BOX_CPUS', 2).to_i
   end
+
+  config.vm.boot_timeout = 600
+
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'ubuntu/disco64' # 19.04
+  config.vm.box      = 'ubuntu/eoan64' # 19.10
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000


### PR DESCRIPTION
This pull request bumps the Ubuntu version from 19.04 to 19.10.

Somehow, `vagrant up` gets time out. Adding `config.vm.boot_timeout = 600` to workaround the time out error below.

```
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu/eoan64'...
==> default: Matching MAC address for NAT networking...
==> default: Checking if box 'ubuntu/eoan64' version '20191022.0.0' is up to date...
==> default: Setting the name of the VM: rails-dev-box_default_1571838570411_83143
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
==> default: Forwarding ports...
    default: 3000 (guest) => 3000 (host) (adapter 1)
    default: 22 (guest) => 2222 (host) (adapter 1)
==> default: Running 'pre-boot' VM customizations...
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
Timed out while waiting for the machine to boot. This means that
Vagrant was unable to communicate with the guest machine within
the configured ("config.vm.boot_timeout" value) time period.

If you look above, you should be able to see the error(s) that
Vagrant had when attempting to connect to the machine. These errors
are usually good hints as to what may be wrong.

If you're using a custom box, make sure that networking is properly
working and you're able to connect to the machine. It is a common
problem that networking isn't setup properly in these boxes.
Verify that authentication configurations are also setup properly,
as well.

If the box appears to be booting properly, you may want to increase
the timeout ("config.vm.boot_timeout") value.
$
```