### PR TITLE
Install `libssl-dev` package to install mysql2 gem

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -44,7 +44,7 @@ sudo -u postgres createdb -O vagrant -E UTF8 -T template0 activerecord_unittest2
 
 debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
 debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'
-install MySQL mysql-server libmysqlclient-dev
+install MySQL mysql-server libmysqlclient-dev libssl-dev
 # Set the password in an environment variable to avoid the warning issued if set with `-p`.
 MYSQL_PWD=root mysql -uroot <<SQL
 CREATE USER 'rails'@'localhost';


### PR DESCRIPTION
It addresses the following error.

Fix #170
```
$ bundle install
... snip ...
Fetching mysql2 0.5.2
Installing mysql2 0.5.2 with native extensions
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20191125-19591-lgv8xlmysql2-0.5.2/gems/mysql2-0.5.2/ext/mysql2
/usr/bin/ruby2.5 -I /usr/local/lib/site_ruby/2.5.0 -r ./siteconf20191125-19591-ogqs32.rb extconf.rb
checking for rb_absint_size()... yes
checking for rb_absint_singlebit_p()... yes
checking for rb_wait_for_single_fd()... yes
-----
Using mysql_config at /usr/bin/mysql_config
-----
checking for mysql.h... yes
checking for errmsg.h... yes
checking for SSL_MODE_DISABLED in mysql.h... yes
checking for SSL_MODE_PREFERRED in mysql.h... yes
checking for SSL_MODE_REQUIRED in mysql.h... yes
checking for SSL_MODE_VERIFY_CA in mysql.h... yes
checking for SSL_MODE_VERIFY_IDENTITY in mysql.h... yes
checking for MYSQL.net.vio in mysql.h... yes
checking for MYSQL.net.pvio in mysql.h... no
checking for MYSQL_ENABLE_CLEARTEXT_PLUGIN in mysql.h... yes
checking for SERVER_QUERY_NO_GOOD_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_NO_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_WAS_SLOW in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_ON in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_OFF in mysql.h... yes
checking for my_bool in mysql.h... yes
-----
Don't know how to set rpath on your system, if MySQL libraries are not in path mysql2 may not load
-----
-----
Setting libpath to /usr/lib/x86_64-linux-gnu
-----
creating Makefile

current directory: /tmp/bundler20191125-19591-lgv8xlmysql2-0.5.2/gems/mysql2-0.5.2/ext/mysql2
make "DESTDIR=" clean

current directory: /tmp/bundler20191125-19591-lgv8xlmysql2-0.5.2/gems/mysql2-0.5.2/ext/mysql2
make "DESTDIR="
compiling client.c
compiling infile.c
compiling mysql2_ext.c
compiling result.c
compiling statement.c
linking shared-object mysql2/mysql2.so
/usr/bin/ld: cannot find -lssl
/usr/bin/ld: cannot find -lcrypto
collect2: error: ld returned 1 exit status
make: *** [Makefile:260: mysql2.so] Error 1

make failed, exit code 2

Gem files will remain installed in /tmp/bundler20191125-19591-lgv8xlmysql2-0.5.2/gems/mysql2-0.5.2 for inspection.
Results logged to /tmp/bundler20191125-19591-lgv8xlmysql2-0.5.2/extensions/x86_64-linux/2.5.0/mysql2-0.5.2/gem_make.out

An error occurred while installing mysql2 (0.5.2), and Bundler cannot continue.
Make sure that `gem install mysql2 -v '0.5.2' --source 'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  mysql2
vagrant@rails-dev-box:~/rails$
```