### PR TITLE
Prevent interactive on provisioning

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+
 # The output of all these installation steps is noisy. With this utility
 # the progress report is nice and concise.
 function install {


### PR DESCRIPTION
When installing Ruby on provisioning it would hang completely 

I think it was because a prompt is blocking installation 
<img width="888" alt="Screenshot 2019-12-23 at 10 43 16" src="https://user-images.githubusercontent.com/5014629/71346992-f4fd6200-2571-11ea-9b57-2e7a203acd23.png">

`DEBIAN_FRONTEND=noninteractive` should prevent interactive during provisioning 

Note that this happens regardless of using the `-y` flag on apt-get