### PR TITLE
increases boot timeout to 600 secs 

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,8 @@ Vagrant.configure('2') do |config|
 
   config.vm.provision :shell, path: 'bootstrap.sh', keep_color: true
 
+  config.vm.boot_timeout = 600
+
   config.vm.provider 'virtualbox' do |v|
     v.memory = ENV.fetch('RAILS_DEV_BOX_RAM', 2048).to_i
     v.cpus   = ENV.fetch('RAILS_DEV_BOX_CPUS', 2).to_i


### PR DESCRIPTION
As the VM may take longer than 5 mins to boot, `vagrant up` times out on waiting to ssh. Increasing the timeout to 10 mins will make the behavior more consistent.

On my OSX Mojave system with 8gb RAM, the Ubuntu eoan64 image takes about 6 minutes to boot.