### PR TITLE
Use Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ That's it.
 After the installation has finished, you can access the virtual machine with
 
     host $ vagrant ssh
-    Welcome to Ubuntu 19.04 (GNU/Linux 5.0.0-32-generic x86_64)
+    Welcome to Ubuntu 20.04 LTS (GNU/Linux 5.4.0-26-generic x86_64)
     ...
     vagrant@rails-dev-box:~$
 
@@ -49,7 +49,7 @@ These can be overridden by setting the environment variables `RAILS_DEV_BOX_RAM`
 
 * Git
 
-* Ruby 2.5
+* Ruby 2.7
 
 * Bundler
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'ubuntu/eoan64' # 19.10
+  config.vm.box      = 'ubuntu/focal64' # 20.04
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000


### PR DESCRIPTION
This pull request bumps the Ubuntu version to Ubuntu 20.04 LTS.

* Ubuntu 20.04 installs Ruby 2.7
```ruby
$ ruby -v
ruby 2.7.0p0 (2019-12-25 revision 647ee6f091) [x86_64-linux-gnu]
```