### PR TITLE
WIP: Adding Libffi to bootstrapping process 

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -72,6 +72,7 @@ rm $kindlegen_tarball
 install 'MuPDF' mupdf mupdf-tools
 install 'FFmpeg' ffmpeg
 install 'Poppler' poppler-utils
+install 'Libffi' libffi-dev
 
 # Needed for docs generation.
 update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8


### PR DESCRIPTION
So that out of the box users can run:

`./railties/exe/rails new cool_app --dev`

Inside the Vagrant container.