### PR TITLE
Remove KindleGen installation

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -60,15 +60,6 @@ install 'Blade dependencies' libncurses5-dev
 install 'ExecJS runtime' nodejs
 install 'Yarn' yarn
 
-# To generate guides in Kindle format.
-install 'ImageMagick' imagemagick
-echo installing KindleGen
-kindlegen_tarball=kindlegen_linux_2.6_i386_v2_9.tar.gz
-wget -q http://kindlegen.s3.amazonaws.com/$kindlegen_tarball
-tar xzf $kindlegen_tarball kindlegen
-mv kindlegen /usr/local/bin
-rm $kindlegen_tarball
-
 install 'MuPDF' mupdf mupdf-tools
 install 'FFmpeg' ffmpeg
 install 'Poppler' poppler-utils


### PR DESCRIPTION
This pull request removes KindleGen installation KindleGen is not available for download.

https://www.amazon.com/gp/feature.html?docId=1000765211

> KindleGen is no longer available for download. Please use Kindle Previewer to convert, preview, and validate your eBooks. Kindle Previewer provides the same functionality of KindleGen and, in addition, provides:

Fix #177