### PR TITLE
Upgrade to Ubuntu 21.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ That's it.
 After the installation has finished, you can access the virtual machine with
 
     host $ vagrant ssh
-    Welcome to Ubuntu 20.10 (GNU/Linux 5.8.0-25-generic x86_64)
+    Welcome to Ubuntu 21.04 (GNU/Linux 5.11.0-16-generic x86_64)
     ...
     vagrant@rails-dev-box:~$
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'ubuntu/groovy64' # 20.10
+  config.vm.box      = 'ubuntu/hirsute64' # 21.04
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -22,14 +22,11 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 echo updating package information
 apt-get -y update >/dev/null 2>&1
 
-install Ruby ruby-full
+install Ruby ruby-full bundler
 install 'development tools' build-essential autoconf libtool
 
 # echo installing current RubyGems
 gem update --system -N >/dev/null 2>&1
-
-echo installing Bundler
-gem install bundler -N >/dev/null 2>&1
 
 install Git git
 install SQLite sqlite3 libsqlite3-dev


### PR DESCRIPTION
This pull request bumps the Ubuntu version from 20.10 to 21.04.

- Install `bundler` by `bundler` package
https://packages.ubuntu.com/hirsute/ruby/bundler

- Warnings `could not change directory to "/home/vagrant": Permission
  denied` during `vagrant up` is likely due to expected change in Ubuntu
  21.04

```
    default: installing PostgreSQL
    default: could not change directory to "/home/vagrant": Permission denied
    default: could not change directory to "/home/vagrant": Permission denied
    default: could not change directory to "/home/vagrant": Permission denied
    default: installing MySQL
```
"Private home directories for Ubuntu 21.04"
https://ubuntu.com/blog/private-home-directories-for-ubuntu-21-04