### PR TITLE
Address `could not change directory to "/home/vagrant": Permission denied`

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -36,9 +36,9 @@ install Redis redis-server
 install RabbitMQ rabbitmq-server
 
 install PostgreSQL postgresql postgresql-contrib libpq-dev
-sudo -u postgres createuser --superuser vagrant
-sudo -u postgres createdb -O vagrant -E UTF8 -T template0 activerecord_unittest
-sudo -u postgres createdb -O vagrant -E UTF8 -T template0 activerecord_unittest2
+sudo -i -u postgres createuser --superuser vagrant
+sudo -i -u postgres createdb -O vagrant -E UTF8 -T template0 activerecord_unittest
+sudo -i -u postgres createdb -O vagrant -E UTF8 -T template0 activerecord_unittest2
 
 debconf-set-selections <<< 'mysql-server mysql-server/root_password password root'
 debconf-set-selections <<< 'mysql-server mysql-server/root_password_again password root'


### PR DESCRIPTION
This pull request addresses these `default: could not change directory to "/home/vagrant": Permission denied` errors during `vagrant up`.

* Without this change:
```
default: installing PostgreSQL
default: could not change directory to "/home/vagrant": Permission denied
default: could not change directory to "/home/vagrant": Permission denied
default: could not change directory to "/home/vagrant": Permission denied
default: installing MySQL
```

* With this change:
```
default: installing PostgreSQL
default: installing MySQL
```