### PR TITLE
Add required `pkg-config` and `libyaml-dev` packages

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,7 +30,7 @@ install 'development tools' build-essential autoconf libtool
 gem update --system -N >/dev/null 2>&1
 
 install Git git
-install SQLite sqlite3 libsqlite3-dev
+install SQLite sqlite3 libsqlite3-dev pkg-config
 install memcached memcached
 install Redis redis-server
 install RabbitMQ rabbitmq-server
@@ -53,6 +53,7 @@ GRANT ALL PRIVILEGES ON activerecord_unittest2.* to 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to 'rails'@'localhost';
 SQL
 
+install 'Psych dependencies' libyaml-dev
 install 'Nokogiri dependencies' libxml2 libxml2-dev libxslt1-dev
 install 'Blade dependencies' libncurses5-dev
 install 'ruby-vips dependencies' libvips


### PR DESCRIPTION
These OS packages are required to install sqlite3 and psych gem

Related to
https://github.com/ruby/psych/pull/541
https://github.com/sparklemotion/sqlite3-ruby/issues/358

### Steps to reproduce

```
- At Vagrant host
git clone https://github.com/rails/rails-dev-box
vagrant up
vagrant ssh
- At rails-dev-box
git clone https://github.com/rails/rails
cd rails
bundle install
```

### Actual behavior without this commit
- psych
```ruby
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20230131-12748-9f8x3tpsych-5.0.1/gems/psych-5.0.1/ext/psych
/usr/bin/ruby3.0 -I /usr/lib/ruby/vendor_ruby -r ./siteconf20230131-12748-84bup1.rb extconf.rb
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/bin/$(RUBY_BASE_NAME)3.0
	--with-libyaml-source-dir
	--without-libyaml-source-dir
	--with-yaml-0.1-config
	--without-yaml-0.1-config
	--with-pkg-config
	--without-pkg-config
	--with-libyaml-dir
	--without-libyaml-dir
	--with-libyaml-include
	--without-libyaml-include=${libyaml-dir}/include
	--with-libyaml-lib
	--without-libyaml-lib=${libyaml-dir}/lib

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /tmp/bundler20230131-12748-9f8x3tpsych-5.0.1/extensions/x86_64-linux/3.0.0/psych-5.0.1/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /tmp/bundler20230131-12748-9f8x3tpsych-5.0.1/gems/psych-5.0.1 for inspection.
Results logged to /tmp/bundler20230131-12748-9f8x3tpsych-5.0.1/extensions/x86_64-linux/3.0.0/psych-5.0.1/gem_make.out

  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:95:in `run'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  /usr/lib/ruby/3.0.0/tempfile.rb:317:in `open'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:26:in `build'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:164:in `build_extension'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:198:in `block in build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `each'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/installer.rb:851:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/source/rubygems.rb:207:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing psych (5.0.1), and Bundler cannot continue.

In Gemfile:
  sdoc was resolved to 2.6.0, which depends on
    rdoc was resolved to 6.5.0, which depends on
      psych
```

- sqlite3
```ruby
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20230131-12748-ltixjjsqlite3-1.5.4/gems/sqlite3-1.5.4/ext/sqlite3
/usr/bin/ruby3.0 -I /usr/lib/ruby/vendor_ruby -r ./siteconf20230131-12748-dyph7k.rb extconf.rb
Building sqlite3-ruby using packaged sqlite3.
Extracting sqlite-autoconf-3400000.tar.gz into tmp/x86_64-linux-gnu/ports/sqlite3/3.40.0... OK
Running 'configure' for sqlite3 3.40.0... OK
Running 'compile' for sqlite3 3.40.0... OK
Running 'install' for sqlite3 3.40.0... OK
Activating sqlite3 3.40.0 (from
/tmp/bundler20230131-12748-ltixjjsqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0)...

Could not configure the build properly (pkg_config). Please install either the `pkg-config` utility or the `pkg-config`
rubygem.

*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/bin/$(RUBY_BASE_NAME)3.0
	--help
	--download-dependencies
	--with-sqlcipher
	--without-sqlcipher
	--with-sqlcipher-dir
	--without-sqlcipher-dir
	--with-sqlcipher-include
	--without-sqlcipher-include
	--with-sqlcipher-lib
	--without-sqlcipher-lib
	--enable-system-libraries
	--disable-system-libraries
	--with-sqlcipher
	--without-sqlcipher
	--with-sqlcipher-dir
	--without-sqlcipher-dir
	--with-sqlcipher-include
	--without-sqlcipher-include
	--with-sqlcipher-lib
	--without-sqlcipher-lib
	--with-sqlite-source-dir
--with-/tmp/bundler20230131-12748-ltixjjsqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-config
--without-/tmp/bundler20230131-12748-ltixjjsqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-config
	--with-pkg-config
	--without-pkg-config

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /tmp/bundler20230131-12748-ltixjjsqlite3-1.5.4/extensions/x86_64-linux/3.0.0/sqlite3-1.5.4/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /tmp/bundler20230131-12748-ltixjjsqlite3-1.5.4/gems/sqlite3-1.5.4 for inspection.
Results logged to /tmp/bundler20230131-12748-ltixjjsqlite3-1.5.4/extensions/x86_64-linux/3.0.0/sqlite3-1.5.4/gem_make.out

  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:95:in `run'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  /usr/lib/ruby/3.0.0/tempfile.rb:317:in `open'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:26:in `build'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:164:in `build_extension'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:198:in `block in build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `each'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/installer.rb:851:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/source/rubygems.rb:207:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing sqlite3 (1.5.4), and Bundler cannot continue.

In Gemfile:
  sqlite3
$
```
