### PR TITLE
Fix psych, sqlite3 and kindlegen installation

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -24,7 +24,7 @@ echo updating package information
 apt-get -y update >/dev/null 2>&1
 
 install Ruby ruby-full bundler
-install 'development tools' build-essential autoconf libtool
+install 'development tools' build-essential autoconf libtool libyaml-dev pkg-config
 
 # echo installing current RubyGems
 gem update --system -N >/dev/null 2>&1
@@ -63,7 +63,8 @@ install 'Yarn' yarn
 install 'ImageMagick' imagemagick
 echo installing KindleGen
 kindlegen_tarball=kindlegen_linux_2.6_i386_v2_9.tar.gz
-wget -q http://kindlegen.s3.amazonaws.com/$kindlegen_tarball
+kindlegen_directory=$(echo -n $kindlegen_tarball | sed 's/.tar.gz//' | tr '.' '_')
+wget -q https://archive.org/download/$kindlegen_directory/$kindlegen_tarball
 tar xzf $kindlegen_tarball kindlegen
 mv kindlegen /usr/local/bin
 rm $kindlegen_tarball


### PR DESCRIPTION
Hello,

I haven't used rails-dev-box for a while. Now when I want to use it the installation fails form 3 reasons for which I propose a patch:
- Add libyaml-dev, required by psych.
- Add pkg-config, required by sqlite3.
- Fetch KindleGen tarball from archive.org since it's discontinued by Amazon.
  -> https://goodereader.com/blog/kindle/amazon-discontinues-kindlegen
  -> https://archive.org/details/kindlegen_linux_2_6_i386_v2_9