### PR TITLE
Upgrade to Ubuntu 23.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ That's it.
 After the installation has finished, you can access the virtual machine with
 
     host $ vagrant ssh
-    Welcome to Ubuntu 22.10 (GNU/Linux 5.19.0-21-generic x86_64)
+    Welcome to Ubuntu 23.04 (GNU/Linux 6.2.0-20-generic x86_64)
     ...
     vagrant@rails-dev-box:~$
 
@@ -49,7 +49,7 @@ These can be overridden by setting the environment variables `RAILS_DEV_BOX_RAM`
 
 * Git
 
-* Ruby 3.0
+* Ruby 3.1
 
 * Bundler
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'ubuntu/kinetic64' # 22.10
+  config.vm.box      = 'ubuntu/lunar64' # 23.04
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000


### PR DESCRIPTION
This pull request upgrades to [Ubuntu 23.04](https://releases.ubuntu.com/23.04/)

* Ruby version is bumped to 3.1
```
$ ruby -v
ruby 3.1.2p20 (2022-04-12 revision 4491bb740a) [x86_64-linux-gnu]
```

Added `libyaml-dev` package for `psych` gem and `pkg-config` package for `sqlite3` gem

- Without these packages, bundle install fails as follows.
```ruby
vagrant@rails-dev-box:~/rails$ bundle install
snip
...
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20230420-11515-5ctry5psych-5.1.0/gems/psych-5.1.0/ext/psych
/usr/bin/ruby3.1 -I /usr/lib/ruby/vendor_ruby -r ./siteconf20230420-11515-ebumh3.rb extconf.rb
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/bin/$(RUBY_BASE_NAME)3.1
	--with-libyaml-source-dir
	--without-libyaml-source-dir
	--with-yaml-0.1-dir
	--without-yaml-0.1-dir
	--with-yaml-0.1-include
	--without-yaml-0.1-include=${yaml-0.1-dir}/include
	--with-yaml-0.1-lib
	--without-yaml-0.1-lib=${yaml-0.1-dir}/lib
	--with-yaml-0.1-config
	--without-yaml-0.1-config
	--with-pkg-config
	--without-pkg-config
	--with-libyaml-dir
	--without-libyaml-dir
	--with-libyaml-include
	--without-libyaml-include=${libyaml-dir}/include
	--with-libyaml-lib
	--without-libyaml-lib=${libyaml-dir}/lib

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /tmp/bundler20230420-11515-5ctry5psych-5.1.0/extensions/x86_64-linux/3.1.0/psych-5.1.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /tmp/bundler20230420-11515-5ctry5psych-5.1.0/gems/psych-5.1.0 for inspection.
Results logged to /tmp/bundler20230420-11515-5ctry5psych-5.1.0/extensions/x86_64-linux/3.1.0/psych-5.1.0/gem_make.out

  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:95:in `run'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  /usr/lib/ruby/3.1.0/tempfile.rb:317:in `open'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:26:in `build'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:164:in `build_extension'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:198:in `block in build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `each'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/installer.rb:851:in `build_extensions'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/source/rubygems.rb:207:in `install'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing psych (5.1.0), and Bundler cannot continue.

In Gemfile:
  sdoc was resolved to 2.6.1, which depends on
    rdoc was resolved to 6.5.0, which depends on
      psych


Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ext/sqlite3
/usr/bin/ruby3.1 -I /usr/lib/ruby/vendor_ruby -r ./siteconf20230420-11515-zpjn1h.rb extconf.rb
Building sqlite3-ruby using packaged sqlite3.
Extracting sqlite-autoconf-3400000.tar.gz into tmp/x86_64-linux-gnu/ports/sqlite3/3.40.0... OK
Running 'configure' for sqlite3 3.40.0... OK
Running 'compile' for sqlite3 3.40.0... OK
Running 'install' for sqlite3 3.40.0... OK
Activating sqlite3 3.40.0 (from
/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0)...

Could not configure the build properly (pkg_config). Please install either the `pkg-config` utility or the `pkg-config`
rubygem.

*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/bin/$(RUBY_BASE_NAME)3.1
	--help
	--download-dependencies
	--with-sqlcipher
	--without-sqlcipher
	--with-sqlcipher-dir
	--without-sqlcipher-dir
	--with-sqlcipher-include
	--without-sqlcipher-include
	--with-sqlcipher-lib
	--without-sqlcipher-lib
	--enable-system-libraries
	--disable-system-libraries
	--with-sqlcipher
	--without-sqlcipher
	--with-sqlcipher-dir
	--without-sqlcipher-dir
	--with-sqlcipher-include
	--without-sqlcipher-include
	--with-sqlcipher-lib
	--without-sqlcipher-lib
	--with-sqlite-source-dir
--with-/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-dir
--without-/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-dir
--with-/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-include
--without-/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-include=${/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-dir}/include
--with-/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-lib
--without-/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-lib=${/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-dir}/lib
--with-/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-config
--without-/tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4/ports/x86_64-linux-gnu/sqlite3/3.40.0/lib/pkgconfig/sqlite3.pc-config
	--with-pkg-config
	--without-pkg-config

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/extensions/x86_64-linux/3.1.0/sqlite3-1.5.4/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/gems/sqlite3-1.5.4 for inspection.
Results logged to /tmp/bundler20230420-11515-mqc3m8sqlite3-1.5.4/extensions/x86_64-linux/3.1.0/sqlite3-1.5.4/gem_make.out

  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:95:in `run'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  /usr/lib/ruby/3.1.0/tempfile.rb:317:in `open'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:26:in `build'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:164:in `build_extension'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:198:in `block in build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `each'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/installer.rb:851:in `build_extensions'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/source/rubygems.rb:207:in `install'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.1.0/gems/bundler-2.3.22/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing sqlite3 (1.5.4), and Bundler cannot continue.

In Gemfile:
  sqlite3
vagrant@rails-dev-box:~/rails$
```