### PR TITLE
Don't update vb guest

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,8 @@ Vagrant.configure('2') do |config|
   config.vm.network :forwarded_port, guest: 3000, host: 3000
 
   config.vm.provision :shell, path: 'bootstrap.sh', keep_color: true
+  
+  config.vbguest.auto_update = false
 
   config.vm.provider 'virtualbox' do |v|
     v.memory = ENV.fetch('RAILS_DEV_BOX_RAM', 2048).to_i


### PR DESCRIPTION
For some reason, I was having an infinite wait on `vagrant up`. 

`VirtualBox Guest Additions: reloading kernel modules and services`