### PR TITLE
Add `libyaml-dev` package to install `psych` gem

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,7 +23,7 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 echo updating package information
 apt-get -y update >/dev/null 2>&1
 
-install Ruby ruby-full bundler
+install Ruby ruby-full bundler libyaml-dev
 install 'development tools' build-essential autoconf libtool
 
 # echo installing current RubyGems


### PR DESCRIPTION
This commit addresses the following error.

```
$ ruby -v
ruby 3.0.2p107 (2021-07-07 revision 0db68f0233) [x86_64-linux-gnu]
$ git clone https://github.com/rails/rails
$ cd rails
$ bundle install
... snip ...
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /tmp/bundler20231023-12516-nihr3xpsych-5.1.1.1/gems/psych-5.1.1.1/ext/psych
/usr/bin/ruby3.0 -I /usr/lib/ruby/vendor_ruby -r ./siteconf20231023-12516-k212j7.rb extconf.rb
checking for yaml.h... no
yaml.h not found
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
    --with-opt-dir
    --without-opt-dir
    --with-opt-include
    --without-opt-include=${opt-dir}/include
    --with-opt-lib
    --without-opt-lib=${opt-dir}/lib
    --with-make-prog
    --without-make-prog
    --srcdir=.
    --curdir
    --ruby=/usr/bin/$(RUBY_BASE_NAME)3.0
    --with-libyaml-source-dir
    --without-libyaml-source-dir
    --with-yaml-0.1-config
    --without-yaml-0.1-config
    --with-pkg-config
    --without-pkg-config
    --with-libyaml-dir
    --without-libyaml-dir
    --with-libyaml-include
    --without-libyaml-include=${libyaml-dir}/include
    --with-libyaml-lib
    --without-libyaml-lib=${libyaml-dir}/lib

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /tmp/bundler20231023-12516-nihr3xpsych-5.1.1.1/extensions/x86_64-linux/3.0.0/psych-5.1.1.1/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /tmp/bundler20231023-12516-nihr3xpsych-5.1.1.1/gems/psych-5.1.1.1 for inspection.
Results logged to /tmp/bundler20231023-12516-nihr3xpsych-5.1.1.1/extensions/x86_64-linux/3.0.0/psych-5.1.1.1/gem_make.out

  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:95:in `run'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:47:in `block in build'
  /usr/lib/ruby/3.0.0/tempfile.rb:317:in `open'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/ext_conf_builder.rb:26:in `build'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:161:in `build_extension'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:195:in `block in build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:192:in `each'
  /usr/lib/ruby/vendor_ruby/rubygems/ext/builder.rb:192:in `build_extensions'
  /usr/lib/ruby/vendor_ruby/rubygems/installer.rb:847:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:72:in `build_extensions'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/rubygems_gem_installer.rb:28:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/source/rubygems.rb:207:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:54:in `install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/gem_installer.rb:16:in `install_from_spec'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:186:in `do_install'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/installer/parallel_installer.rb:177:in `block in worker_pool'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:62:in `apply_func'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:57:in `block in process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `loop'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:54:in `process_queue'
  /var/lib/gems/3.0.0/gems/bundler-2.3.22/lib/bundler/worker.rb:91:in `block (2 levels) in create_threads'

An error occurred while installing psych (5.1.1.1), and Bundler cannot continue.

In Gemfile:
  sdoc was resolved to 3.0.0.alpha, which depends on
    rdoc was resolved to 6.5.0, which depends on
      psych
$
```