### PR TITLE
Set `MYSQL_SOCK` environment variable for Trilogy

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -52,6 +52,8 @@ GRANT ALL PRIVILEGES ON activerecord_unittest.* to 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON activerecord_unittest2.* to 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to 'rails'@'localhost';
 SQL
+# To address `unable to connect to /tmp/mysql.sock` for trilogy
+echo "export MYSQL_SOCK=/var/run/mysqld/mysqld.sock" >> /home/vagrant/.bashrc
 
 install 'Psych dependencies' libyaml-dev
 install 'Nokogiri dependencies' libxml2 libxml2-dev libxslt1-dev


### PR DESCRIPTION
This commit addresses the following exception.

- Steps to reproduce
```ruby
vagrant ssh
git clone https://github.com/rails/rails
cd rails
bundle install
cd activerecord
bundle exec rake test_trilogy
```

- Exception fixed by this commit
```ruby
Using trilogy
/home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:35:in `rescue in new_client': No such file or directory - trilogy_connect - unable to connect to /tmp/mysql.sock (ActiveRecord::ConnectionNotEstablished)
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:31:in `new_client'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:179:in `connect'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:187:in `reconnect'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:692:in `block in reconnect!'
	from /home/vagrant/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:691:in `reconnect!'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:795:in `verify!'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:802:in `connect!'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1008:in `block in with_raw_connection'
	from /home/vagrant/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1007:in `with_raw_connection'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:195:in `get_full_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:87:in `get_database_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:41:in `block in server_version'
	from /usr/lib/ruby/3.1.0/monitor.rb:202:in `synchronize'
	from /usr/lib/ruby/3.1.0/monitor.rb:202:in `mon_synchronize'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:41:in `server_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:122:in `server_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:878:in `database_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:191:in `full_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:93:in `mariadb?'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:136:in `row_format_dynamic_by_default?'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:144:in `default_row_format'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:80:in `create_table'
	from /home/vagrant/rails/activerecord/lib/active_record/migration/default_strategy.rb:10:in `method_missing'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:1046:in `block in method_missing'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:1016:in `block in say_with_time'
	from /usr/lib/ruby/3.1.0/benchmark.rb:296:in `measure'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:1016:in `say_with_time'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:1035:in `method_missing'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:566:in `create_table'
	from /home/vagrant/rails/activerecord/test/schema/schema.rb:11:in `block in <top (required)>'
	from /home/vagrant/rails/activerecord/lib/active_record/schema.rb:55:in `instance_eval'
	from /home/vagrant/rails/activerecord/lib/active_record/schema.rb:55:in `define'
	from /home/vagrant/rails/activerecord/lib/active_record/schema.rb:50:in `define'
	from /home/vagrant/rails/activerecord/test/schema/schema.rb:3:in `<top (required)>'
	from /home/vagrant/rails/activerecord/test/support/load_schema_helper.rb:12:in `load'
	from /home/vagrant/rails/activerecord/test/support/load_schema_helper.rb:12:in `load_schema'
	from /home/vagrant/rails/activerecord/test/cases/test_case.rb:241:in `<class:TestCase>'
	from /home/vagrant/rails/activerecord/test/cases/test_case.rb:21:in `<module:ActiveRecord>'
	from /home/vagrant/rails/activerecord/test/cases/test_case.rb:17:in `<top (required)>'
	from /home/vagrant/rails/activerecord/test/cases/helper.rb:8:in `require'
	from /home/vagrant/rails/activerecord/test/cases/helper.rb:8:in `<top (required)>'
	from /home/vagrant/rails/activerecord/test/cases/active_record_schema_test.rb:3:in `require'
	from /home/vagrant/rails/activerecord/test/cases/active_record_schema_test.rb:3:in `<top (required)>'
	from /var/lib/gems/3.1.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `require'
	from /var/lib/gems/3.1.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /var/lib/gems/3.1.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `select'
	from /var/lib/gems/3.1.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `<main>'
/var/lib/gems/3.1.0/gems/trilogy-2.6.0/lib/trilogy.rb:16:in `_initialize': No such file or directory - trilogy_connect - unable to connect to /tmp/mysql.sock (Trilogy::SyscallError::ENOENT)
	from /var/lib/gems/3.1.0/gems/trilogy-2.6.0/lib/trilogy.rb:16:in `initialize'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:33:in `new'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:33:in `new_client'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:179:in `connect'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:187:in `reconnect'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:692:in `block in reconnect!'
	from /home/vagrant/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:691:in `reconnect!'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:795:in `verify!'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:802:in `connect!'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1008:in `block in with_raw_connection'
	from /home/vagrant/rails/activesupport/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:1007:in `with_raw_connection'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:195:in `get_full_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:87:in `get_database_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:41:in `block in server_version'
	from /usr/lib/ruby/3.1.0/monitor.rb:202:in `synchronize'
	from /usr/lib/ruby/3.1.0/monitor.rb:202:in `mon_synchronize'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/pool_config.rb:41:in `server_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract/connection_pool.rb:122:in `server_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_adapter.rb:878:in `database_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/trilogy_adapter.rb:191:in `full_version'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/abstract_mysql_adapter.rb:93:in `mariadb?'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:136:in `row_format_dynamic_by_default?'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:144:in `default_row_format'
	from /home/vagrant/rails/activerecord/lib/active_record/connection_adapters/mysql/schema_statements.rb:80:in `create_table'
	from /home/vagrant/rails/activerecord/lib/active_record/migration/default_strategy.rb:10:in `method_missing'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:1046:in `block in method_missing'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:1016:in `block in say_with_time'
	from /usr/lib/ruby/3.1.0/benchmark.rb:296:in `measure'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:1016:in `say_with_time'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:1035:in `method_missing'
	from /home/vagrant/rails/activerecord/lib/active_record/migration.rb:566:in `create_table'
	from /home/vagrant/rails/activerecord/test/schema/schema.rb:11:in `block in <top (required)>'
	from /home/vagrant/rails/activerecord/lib/active_record/schema.rb:55:in `instance_eval'
	from /home/vagrant/rails/activerecord/lib/active_record/schema.rb:55:in `define'
	from /home/vagrant/rails/activerecord/lib/active_record/schema.rb:50:in `define'
	from /home/vagrant/rails/activerecord/test/schema/schema.rb:3:in `<top (required)>'
	from /home/vagrant/rails/activerecord/test/support/load_schema_helper.rb:12:in `load'
	from /home/vagrant/rails/activerecord/test/support/load_schema_helper.rb:12:in `load_schema'
	from /home/vagrant/rails/activerecord/test/cases/test_case.rb:241:in `<class:TestCase>'
	from /home/vagrant/rails/activerecord/test/cases/test_case.rb:21:in `<module:ActiveRecord>'
	from /home/vagrant/rails/activerecord/test/cases/test_case.rb:17:in `<top (required)>'
	from /home/vagrant/rails/activerecord/test/cases/helper.rb:8:in `require'
	from /home/vagrant/rails/activerecord/test/cases/helper.rb:8:in `<top (required)>'
	from /home/vagrant/rails/activerecord/test/cases/active_record_schema_test.rb:3:in `require'
	from /home/vagrant/rails/activerecord/test/cases/active_record_schema_test.rb:3:in `<top (required)>'
	from /var/lib/gems/3.1.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `require'
	from /var/lib/gems/3.1.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:21:in `block in <main>'
	from /var/lib/gems/3.1.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `select'
	from /var/lib/gems/3.1.0/gems/rake-13.1.0/lib/rake/rake_test_loader.rb:6:in `<main>'
rake aborted!
```