### PR TITLE
Add `imagemagick` package

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -66,6 +66,7 @@ install 'MuPDF' mupdf mupdf-tools
 install 'FFmpeg' ffmpeg
 install 'Poppler' poppler-utils
 install 'tzdata-legacy' tzdata-legacy
+install 'ImageMagick' imagemagick
 
 # Needed for docs generation.
 update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8


### PR DESCRIPTION
This commit addresses the "MiniMagick::Invalid: You must have ImageMagick or GraphicsMagick installed" error.

- Steps to reproduce
```rub
vagrant ssh
git clone https://github.com/rails/rails
cd rails
bundle install
cd activestorage
bin/test test/models/representation_test.rb -n test_representing_an_image
```

- This commit addresses the following error:
```ruby
$ bin/test test/models/representation_test.rb -n test_representing_an_image
... snip ...
E

Error:
ActiveStorage::RepresentationTest#test_representing_an_image:
MiniMagick::Invalid: You must have ImageMagick or GraphicsMagick installed
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:221:in `rescue in validate!'
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:218:in `validate!'
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:131:in `block in create'
    <internal:kernel>:90:in `tap'
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:130:in `create'
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:34:in `read'
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:108:in `block in open'
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:108:in `open'
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:108:in `open'
    /var/lib/gems/3.1.0/gems/mini_magick-4.12.0/lib/mini_magick/image.rb:108:in `open'
    /home/vagrant/rails/activestorage/test/test_helper.rb:70:in `read_image'
    /home/vagrant/rails/activestorage/test/models/representation_test.rb:11:in `block in <class:RepresentationTest>'

bin/test test/models/representation_test.rb:7

Finished in 0.472072s, 2.1183 runs/s, 0.0000 assertions/s.
1 runs, 0 assertions, 0 failures, 1 errors, 0 skips
$
```