### PR TITLE
Add explicit URL for Ubuntu 23.10 box (no longer hosted on Vagrant Cl…

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,6 +2,7 @@
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
   config.vm.box      = 'ubuntu/mantic64' # 23.10
+  config.vm.box_url = "https://cloud-images.ubuntu.com/releases/23.10/release/ubuntu-23.10-server-cloudimg-amd64-vagrant.box"
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000


### PR DESCRIPTION
…oud)

Note: Mantic64 (23.10) is now [END OF LIFE - for reference only]. The most current Ubuntu image that is not EOL is Jammy64 (22.04) & this is still available on Vagrant Cloud.

Ubuntu will no longer provide official Vagrant images starting with version 24. For more details, see the release notes: [Ubuntu 24.04 LTS - Noble Numbat](https://discourse.ubuntu.com/t/ubuntu-24-04-lts-noble-numbat-release-notes/39890).