### PR TITLE
Use Ubuntu 24.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ That's it.
 After the installation has finished, you can access the virtual machine with
 
     host $ vagrant ssh
-    Welcome to Ubuntu 23.10 (GNU/Linux 6.5.0-14-generic x86_64)
+    Welcome to Ubuntu 24.04.2 LTS (GNU/Linux 6.8.0-86-generic x86_64)
     ...
     vagrant@rails-dev-box:~$
 
@@ -49,7 +49,7 @@ These can be overridden by setting the environment variables `RAILS_DEV_BOX_RAM`
 
 * Git
 
-* Ruby 3.1
+* Ruby 4.x (installed via [mise](https://mise.jdx.dev/))
 
 * Bundler
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure('2') do |config|
-  config.vm.box      = 'ubuntu/mantic64' # 23.10
+  config.vm.box      = 'bento/ubuntu-24.04' # 24.04 LTS
   config.vm.hostname = 'rails-dev-box'
 
   config.vm.network :forwarded_port, guest: 3000, host: 3000

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -23,11 +23,15 @@ echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/source
 echo updating package information
 apt-get -y update >/dev/null 2>&1
 
-install Ruby ruby-full bundler libyaml-dev
+install 'Ruby build dependencies' libyaml-dev libssl-dev libreadline-dev zlib1g-dev
 install 'development tools' build-essential autoconf libtool
 
-# echo installing current RubyGems
-gem update --system -N >/dev/null 2>&1
+echo installing mise
+curl -fsSL https://mise.run | HOME=/home/vagrant sudo -u vagrant bash
+echo 'eval "$(/home/vagrant/.local/bin/mise activate bash)"' >> /home/vagrant/.bashrc
+
+echo installing Ruby via mise
+sudo -u vagrant HOME=/home/vagrant /home/vagrant/.local/bin/mise use --global ruby@4 >/dev/null 2>&1
 
 install Git git
 install SQLite sqlite3 libsqlite3-dev pkg-config
@@ -52,10 +56,14 @@ GRANT ALL PRIVILEGES ON activerecord_unittest.* to 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON activerecord_unittest2.* to 'rails'@'localhost';
 GRANT ALL PRIVILEGES ON inexistent_activerecord_unittest.* to 'rails'@'localhost';
 SQL
-# To address `unable to connect to /tmp/mysql.sock` for trilogy
-echo "export MYSQL_SOCK=/var/run/mysqld/mysqld.sock" >> /home/vagrant/.bashrc
+# To address `unable to connect to /tmp/mysql.sock` for trilogy,
+# and to pass MySQL root password in railties tests.
+# /etc/environment is parsed by PAM for login sessions to expose these variables broadly.
+cat >> /etc/environment <<'ENV'
+MYSQL_SOCK=/var/run/mysqld/mysqld.sock
+MYSQL_CODESPACES=1
+ENV
 
-install 'Psych dependencies' libyaml-dev
 install 'Nokogiri dependencies' libxml2 libxml2-dev libxslt1-dev
 install 'Blade dependencies' libncurses5-dev
 install 'ruby-vips dependencies' libvips
@@ -68,9 +76,14 @@ install 'Poppler' poppler-utils
 install 'tzdata-legacy' tzdata-legacy
 install 'ImageMagick' imagemagick
 
+echo installing Google Chrome
+curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /usr/share/keyrings/googlechrome-linux-keyring.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/googlechrome-linux-keyring.gpg] http://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+apt-get -y update >/dev/null 2>&1
+install 'Google Chrome' google-chrome-stable
+
 # Needed for docs generation.
 update-locale LANG=en_US.UTF-8 LANGUAGE=en_US.UTF-8 LC_ALL=en_US.UTF-8
 
 echo "test -d /vagrant/rails && cd /vagrant/rails" >> /home/vagrant/.bashrc
-
 echo 'all set, rock on!'


### PR DESCRIPTION
- Switch from ubuntu/mantic64 (23.10) to bento/ubuntu-24.04 because the Ubuntu "official" Vagrant image is no longer available from Ubuntu (rails/rails-dev-box#215). HashiCorp recommends Bento boxes for base OS environments: https://developer.hashicorp.com/vagrant/docs/boxes

- Ubuntu 24.04 ships Ruby 3.2 which is below the Rails main branch requirement of Ruby 3.3.0, so install Ruby 4.x via mise (https://launchpad.net/ubuntu/noble/+package/ruby)

- Set MYSQL_SOCK in ~/.bashrc so the Trilogy adapter can connect to MySQL

- Set MYSQL_CODESPACES=1 in ~/.bashrc so railties tests supply the correct MySQL root password ('root')

- Added Google Chrome installation steps so future vagrant up provisions Chrome for ActionPack system tests.